### PR TITLE
Replace "length" with "size" to be compatible with other types than String (e.g. std::vector<char>)

### DIFF
--- a/include/xcdat/code_table.hpp
+++ b/include/xcdat/code_table.hpp
@@ -40,7 +40,7 @@ class code_table {
             for (std::uint8_t ch : key) {
                 counter[ch].freq += 1;
             }
-            m_max_length = std::max<std::uint64_t>(m_max_length, key.length());
+            m_max_length = std::max<std::uint64_t>(m_max_length, key.size());
         }
 
         {


### PR DESCRIPTION
As specified in the documentation, it should be possible to use an `std::vector<char>` as template class for `Strings`. However, the `length` function does not exist for `std::vector` (although both do the same thing).
This replaces the `.length()` with `.size()` in `include/xcdat/code_table.hpp]`.